### PR TITLE
Update Java Version to 17 in Android Fastlane CI/CD Workflow

### DIFF
--- a/.github/workflows/android_fastlane_firebase_app_distribution_workflow.yml
+++ b/.github/workflows/android_fastlane_firebase_app_distribution_workflow.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.3.5'
+          ruby-version: '3.3.4'
           bundler-cache: false # Disable bundler-cache to manage dependencies manually
 
       - name: Update Gemfile.lock platforms

--- a/.github/workflows/android_fastlane_firebase_app_distribution_workflow.yml
+++ b/.github/workflows/android_fastlane_firebase_app_distribution_workflow.yml
@@ -12,11 +12,11 @@ jobs:
       - name: Checkout My Repository
         uses: actions/checkout@v2
 
-      - name: Setup JDK 11
+      - name: Setup JDK 17
         uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
 
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.3.4'
+          ruby-version: '3.3.5'
           bundler-cache: false # Disable bundler-cache to manage dependencies manually
 
       - name: Update Gemfile.lock platforms


### PR DESCRIPTION
This PR updates the Java version used in the GitHub Actions workflow for Android Fastlane app distribution from Java 11 to Java 17.

Key changes include:
- Updated the `Setup JDK` step in the workflow to specify `java-version: '17'`, ensuring compatibility with the latest features and improvements in the Java ecosystem.

This change aims to enhance the build process and leverage the benefits of using a more recent Java version. 
