### PR TITLE
Implement FavoritesCubit and FavoritesView for Managing Favorite Azkar

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:wirdak/core/common/cubits/favorites_cubit.dart';
 import 'package:wirdak/core/utils/theme/theme.dart';
 import 'package:wirdak/features/home/presentation/views/home_view.dart';
 
@@ -12,15 +14,18 @@ class MyApp extends StatelessWidget {
     return ScreenUtilInit(
       designSize: const Size(375, 889),
       minTextAdapt: true,
-       builder: (_, child) => MaterialApp(
-        theme: TTheme.lightTheme,
-        debugShowCheckedModeBanner: false,
-        locale: const Locale('ar'),
-        localizationsDelegates: _localizationsDelegates,
-        supportedLocales: _supportedLocales,
-        builder: (context, child) =>
-            _buildDirectionalityWrapper(context, child),
-        home: const HomeView(), // Placeholder home widget
+      builder: (_, child) => BlocProvider(
+        create: (context) => FavoritesCubit(),
+        child: MaterialApp(
+          theme: TTheme.lightTheme,
+          debugShowCheckedModeBanner: false,
+          locale: const Locale('ar'),
+          localizationsDelegates: _localizationsDelegates,
+          supportedLocales: _supportedLocales,
+          builder: (context, child) =>
+              _buildDirectionalityWrapper(context, child),
+          home: const HomeView(), // Placeholder home widget
+        ),
       ),
     );
   }

--- a/lib/core/common/cubits/favorites_cubit.dart
+++ b/lib/core/common/cubits/favorites_cubit.dart
@@ -1,0 +1,34 @@
+import 'package:bloc/bloc.dart';
+import 'package:equatable/equatable.dart';
+import 'package:wirdak/core/common/models/azkar_model.dart';
+
+part 'favorites_state.dart';
+
+class FavoritesCubit extends Cubit<FavoritesState> {
+  // Local variable to store favorites
+  final List<ZikerModel> _favorites = [];
+
+  FavoritesCubit() : super(const FavoritesState(favorites: []));
+
+  void addToFavorites(ZikerModel ziker) {
+    if (!_favorites.contains(ziker)) {
+      _favorites.add(ziker);
+      print('Added to favorites: ${ziker.id}');
+      print('Current favorites: ${_favorites.map((e) => e.id)}');
+      emit(FavoritesState(
+          favorites: List.from(_favorites))); // Emit updated state
+    } else {
+      print('Ziker already in favorites: ${ziker.id}');
+    }
+  }
+
+  void removeFromFavorites(ZikerModel ziker) {
+    if (_favorites.remove(ziker)) {
+      print('Removed from favorites: ${ziker.id}');
+      emit(FavoritesState(
+          favorites: List.from(_favorites))); // Emit updated state
+    } else {
+      print('Ziker not found in favorites: ${ziker.id}');
+    }
+  }
+}

--- a/lib/core/common/cubits/favorites_state.dart
+++ b/lib/core/common/cubits/favorites_state.dart
@@ -1,0 +1,10 @@
+part of 'favorites_cubit.dart';
+
+class FavoritesState extends Equatable {
+  final List<ZikerModel> favorites;
+
+  const FavoritesState({required this.favorites});
+
+  @override
+  List<Object> get props => [favorites];
+}

--- a/lib/core/common/models/azkar_model.dart
+++ b/lib/core/common/models/azkar_model.dart
@@ -1,4 +1,6 @@
-class ZikerModel {
+import 'package:equatable/equatable.dart';
+
+class ZikerModel extends Equatable {
   final int id;
   final String text;
   final int count;
@@ -28,4 +30,10 @@ class ZikerModel {
       'filename': filename,
     };
   }
+
+  @override
+  List<Object?> get props => [id, text, count, filename];
+
+  @override
+  bool get stringify => true; // Optional for better debugging
 }

--- a/lib/core/common/widgets/ziker_actions.dart
+++ b/lib/core/common/widgets/ziker_actions.dart
@@ -1,20 +1,30 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:wirdak/core/common/cubits/favorites_cubit.dart';
 import 'package:wirdak/core/common/cubits/ziker_cubit.dart';
 import 'package:wirdak/core/common/models/azkar_model.dart';
 import 'package:wirdak/core/common/widgets/ziker_thwab.dart';
 import 'package:wirdak/core/utils/spacing.dart';
 
-class ZikerActions extends StatelessWidget {
+class ZikerActions extends StatefulWidget {
   final ZikerModel ziker;
+  bool isFavorite;
+  ZikerActions({
+    super.key,
+    required this.ziker,
+    required this.isFavorite,
+  });
 
-  const ZikerActions({super.key, required this.ziker});
+  @override
+  State<ZikerActions> createState() => _ZikerActionsState();
+}
 
+class _ZikerActionsState extends State<ZikerActions> {
   @override
   Widget build(BuildContext context) {
     return BlocProvider(
-      create: (_) => ZikerCubit(ziker.count),
+      create: (_) => ZikerCubit(widget.ziker.count),
       child: BlocBuilder<ZikerCubit, ZikerState>(
         builder: (context, state) {
           return Container(
@@ -41,11 +51,20 @@ class ZikerActions extends StatelessWidget {
                   children: [
                     IconButton(
                       onPressed: () {
+                        final cubit = context.read<FavoritesCubit>();
+                        if (widget.isFavorite) {
+                          cubit.removeFromFavorites(widget.ziker);
+                        } else {
+                          cubit.addToFavorites(widget.ziker);
+                        }
                         context.read<ZikerCubit>().toggleFavorite();
+                        setState(() {
+                          widget.isFavorite = !widget.isFavorite;
+                        });
                       },
                       iconSize: 24,
                       icon: Icon(
-                        state.isFavorite
+                        widget.isFavorite
                             ? Icons.favorite
                             : Icons.favorite_border,
                         color: const Color(0xFF005773),

--- a/lib/core/common/widgets/ziker_card.dart
+++ b/lib/core/common/widgets/ziker_card.dart
@@ -8,8 +8,8 @@ import 'package:wirdak/core/utils/spacing.dart';
 
 class ZikerCard extends StatelessWidget {
   final ZikerModel ziker;
-
-  const ZikerCard({super.key, required this.ziker});
+  final bool isFavorite;
+  const ZikerCard({super.key, required this.ziker, required this.isFavorite});
 
   @override
   Widget build(BuildContext context) {
@@ -66,7 +66,7 @@ class ZikerCard extends StatelessWidget {
             SvgPicture.asset(ImageStrings.down),
             verticalSpace(16),
             
-            ZikerActions(ziker: ziker),
+            ZikerActions(isFavorite: isFavorite, ziker: ziker),
           ],
         ),
       ),

--- a/lib/features/home/presentation/widgets/features_list.dart
+++ b/lib/features/home/presentation/widgets/features_list.dart
@@ -3,6 +3,7 @@ import 'package:wirdak/core/utils/constants/image_strings.dart';
 import 'package:wirdak/core/utils/spacing.dart';
 import 'package:wirdak/features/home/presentation/widgets/features_list_item.dart';
 import 'package:wirdak/features/reading_azkar/presentation/views/all_azkar_view.dart';
+import 'package:wirdak/features/reading_azkar/presentation/views/favourite_view.dart';
 
 class FeaturesList extends StatelessWidget {
   const FeaturesList({
@@ -40,21 +41,28 @@ class FeaturesList extends StatelessWidget {
         Row(
           mainAxisAlignment: MainAxisAlignment.spaceEvenly,
           children: [
-            GestureDetector(
-              onTap: () {
-                Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (context) => const AllAzkarView(),
-                    ));
-              },
-              child: const FeaturesListItem(
-                  title: "أذكار متنوعة", imagePath: ImageStrings.noteBook),
-            ),
+            FeaturesListItem(
+                onTap: () {
+                  Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) => const AllAzkarView(),
+                      ));
+                },
+                title: "أذكار متنوعة",
+                imagePath: ImageStrings.noteBook),
             const FeaturesListItem(
                 title: "أقرب المساجد", imagePath: ImageStrings.mosqueSvg),
-            const FeaturesListItem(
-                title: "المفضلة", imagePath: ImageStrings.favorites),
+            FeaturesListItem(
+                onTap: () {
+                  Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) => const FavoritesView(),
+                      ));
+                },
+                title: "المفضلة",
+                imagePath: ImageStrings.favorites),
           ],
         )
       ],

--- a/lib/features/home/presentation/widgets/features_list_item.dart
+++ b/lib/features/home/presentation/widgets/features_list_item.dart
@@ -5,49 +5,52 @@ import 'package:flutter_svg/svg.dart';
 class FeaturesListItem extends StatelessWidget {
   final String title;
   final String imagePath;
-
+  final void Function()? onTap;
   const FeaturesListItem(
-      {super.key, required this.title, required this.imagePath});
+      {super.key, required this.title, required this.imagePath, this.onTap});
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      children: [
-        Container(
-          width: 78.w,
-          height: 77.h,
-          padding: const EdgeInsets.all(4),
-          decoration: ShapeDecoration(
-            color: Colors.white,
-            shape:
-                RoundedRectangleBorder(borderRadius: BorderRadius.circular(4)),
-            shadows: const [
-              BoxShadow(
-                color: Color(0x19000000),
-                blurRadius: 19.52,
-                offset: Offset(0, 2.44),
-                spreadRadius: 0,
-              ),
-            ],
-          ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.center,
-            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-            children: [
-              SvgPicture.asset(imagePath, width: 32, height: 32),
-              Text(
-                title,
-                style: TextStyle(
-                  color: const Color(0xFF01B7F1),
-                  fontSize: 12.sp,
-                  fontFamily: 'Poppins',
-                  fontWeight: FontWeight.w600,
+    return GestureDetector(
+      onTap: onTap,
+      child: Column(
+        children: [
+          Container(
+            width: 78.w,
+            height: 77.h,
+            padding: const EdgeInsets.all(4),
+            decoration: ShapeDecoration(
+              color: Colors.white,
+              shape:
+                  RoundedRectangleBorder(borderRadius: BorderRadius.circular(4)),
+              shadows: const [
+                BoxShadow(
+                  color: Color(0x19000000),
+                  blurRadius: 19.52,
+                  offset: Offset(0, 2.44),
+                  spreadRadius: 0,
                 ),
-              ),
-            ],
+              ],
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              children: [
+                SvgPicture.asset(imagePath, width: 32, height: 32),
+                Text(
+                  title,
+                  style: TextStyle(
+                    color: const Color(0xFF01B7F1),
+                    fontSize: 12.sp,
+                    fontFamily: 'Poppins',
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ],
+            ),
           ),
-        ),
-      ],
+        ],
+      ),
     );
   }
 }

--- a/lib/features/reading_azkar/presentation/views/favourite_view.dart
+++ b/lib/features/reading_azkar/presentation/views/favourite_view.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:wirdak/core/common/cubits/favorites_cubit.dart';
+import 'package:wirdak/core/common/widgets/custom_app_bar.dart';
+import 'package:wirdak/core/common/widgets/ziker_card.dart';
+
+class FavoritesView extends StatelessWidget {
+  const FavoritesView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: const CustomAppBar(title: 'المفضلة'),
+      body: BlocBuilder<FavoritesCubit, FavoritesState>(
+        builder: (context, state) {
+          if (state.favorites.isEmpty) {
+            return const Center(child: Text('لا يوجد مفضلة'));
+          }
+          return ListView.builder(
+            itemCount: state.favorites.length,
+            itemBuilder: (context, index) {
+              return ZikerCard(isFavorite: true, ziker: state.favorites[index]);
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/features/reading_azkar/presentation/views/ziker_view.dart
+++ b/lib/features/reading_azkar/presentation/views/ziker_view.dart
@@ -16,7 +16,7 @@ class ZikerView extends StatelessWidget {
       body: ListView.builder(
         itemCount: zikerList.length,
         itemBuilder: (context, index) {
-          return ZikerCard(ziker: zikerList[index]);
+          return ZikerCard(isFavorite: false, ziker: zikerList[index]);
         },
       ),
     );


### PR DESCRIPTION
This PR adds functionality for managing favorite Azkar using the Bloc pattern. Key components include:

- **FavoritesCubit**: Manages a list of favorite ZikerModel instances. Includes methods for adding and removing favorites with state emissions.

- **FavoritesState**: A state class that holds the current list of favorite Azkar, extending Equatable for efficient state comparison.

- **FavoritesView**: Displays a list of favorite Azkar. If there are no favorites, a message is shown indicating that the list is empty.

- **Integration with ZikerActions**: The toggle button for favorites has been integrated with the FavoritesCubit, allowing users to add or remove Azkar from their favorites.

This implementation enhances the user experience by allowing them to manage their favorite Azkar efficiently.
